### PR TITLE
Speed up native CI tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,17 +11,21 @@ jobs:
   test:
     strategy:
       matrix:
-        os:
-          - macOS-latest
-          - windows-latest
-          - ubuntu-latest
+        os: [macos-latest,  windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            NATIVE_TEST_TASK: :mordant:macosX64Test
+          - os: windows-latest
+            NATIVE_TEST_TASK: :mordant:mingwX64Test
+          - os: ubuntu-latest
+            NATIVE_TEST_TASK: :mordant:linuxX64Test
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - uses: eskatos/gradle-command-action@v1
         with:
           dependencies-cache-enabled: true
-          arguments: :mordant:check --stacktrace
+          arguments: :mordant:jvmTest :mordant:jsTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,21 @@ jobs:
   test:
     strategy:
       matrix:
-        os:
-          - macOS-latest
-          - windows-latest
-          - ubuntu-latest
+        os: [macos-latest,  windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            NATIVE_TEST_TASK: :mordant:macosX64Test
+          - os: windows-latest
+            NATIVE_TEST_TASK: :mordant:mingwX64Test
+          - os: ubuntu-latest
+            NATIVE_TEST_TASK: :mordant:linuxX64Test
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - uses: eskatos/gradle-command-action@v1
         with:
           dependencies-cache-enabled: true
-          arguments: :mordant:check --stacktrace
+          arguments: :mordant:jvmTest :mordant:jsTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip


### PR DESCRIPTION
`gradle check` will cross compile linux binaries on all platforms. We can save time by only compiling the tests that can actually run.