### PR TITLE
Enable IR backend for JS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           - os: windows-latest
             NATIVE_TEST_TASK: :mordant:mingwX64Test
           - os: ubuntu-latest
-            NATIVE_TEST_TASK: :mordant:linuxX64Test :mordant:linuxX64BackgroundTest
+            NATIVE_TEST_TASK: :mordant:jsLegacyTest :mordant:linuxX64Test :mordant:linuxX64BackgroundTest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
           java-version: 11
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: :mordant:jvmTest :mordant:jsTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
+          arguments: :mordant:jvmTest :mordant:jsIrTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
             NATIVE_TEST_TASK: :mordant:macosX64Test
           - os: windows-latest
             NATIVE_TEST_TASK: :mordant:mingwX64Test
+          # ubuntu is the fastest runner, so only run legacy JS tests there.
           - os: ubuntu-latest
-            NATIVE_TEST_TASK: :mordant:linuxX64Test :mordant:linuxX64BackgroundTest
+            NATIVE_TEST_TASK: :mordant:jsLegacyTest :mordant:linuxX64Test :mordant:linuxX64BackgroundTest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +27,7 @@ jobs:
           java-version: 11
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: :mordant:jvmTest :mordant:jsTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
+          arguments: :mordant:jvmTest :mordant:jsIrTest ${{matrix.NATIVE_TEST_TASK}} --stacktrace
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip

--- a/mordant/build.gradle.kts
+++ b/mordant/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 
 kotlin {
     jvm()
-    js(LEGACY) {
+    js(BOTH) {
         nodejs()
         browser()
     }


### PR DESCRIPTION
This appears to be blocked by [KT-43374](https://youtrack.jetbrains.com/issue/KT-43374)