### PR TITLE
Fix hyperlinks terminal detection for kitty + alacritty

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/TerminalDetection.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/TerminalDetection.kt
@@ -46,7 +46,10 @@ internal object TerminalDetection {
         return forcedColor() != NONE && (isWindowsTerminal() || when (getTermProgram()) {
             "hyper", "wezterm" -> true
             "iterm.app" -> isRecentITerm()
-            else -> false
+            else -> when (getTerm()) {
+                "xterm-kitty", "alacritty" -> true
+                else -> false
+            }
         })
     }
 


### PR DESCRIPTION
They now both support hyperlinks

Kitty since 0.19.0 [2020-10-04]
https://sw.kovidgoyal.net/kitty/changelog/#id30

Alacritty since 0.11.0 [2022-10-13]
https://github.com/alacritty/alacritty/releases/tag/v0.11.0