### PR TITLE
fix: text truncation not being applied when no wrap is configured

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/widgets/Text.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/widgets/Text.kt
@@ -131,15 +131,21 @@ class Text internal constructor(
                 }
 
                 // overflow wrap
-                if (cellWidth > wrapWidth) {
+                if (width + cellWidth > wrapWidth) {
                     when (overflowWrap) {
                         OverflowWrap.NORMAL -> {
                         }
                         OverflowWrap.TRUNCATE -> {
-                            span = Span.word(span.text.take(wrapWidth), span.style)
+                            span = Span.word(span.text.take(wrapWidth - width), span.style)
+                            line.add(span)
+                            breakLine()
+                            break
                         }
                         OverflowWrap.ELLIPSES -> {
-                            span = Span.word(span.text.take((wrapWidth - 1)) + "…", span.style)
+                            span = Span.word(span.text.take((wrapWidth - 1 - width)) + "…", span.style)
+                            line.add(span)
+                            breakLine()
+                            break
                         }
                         OverflowWrap.BREAK_WORD -> {
                             span.text.chunked(wrapWidth).forEach {

--- a/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/rendering/TextOverflowWrapTest.kt
+++ b/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/rendering/TextOverflowWrapTest.kt
@@ -30,9 +30,22 @@ class TextOverflowWrapTest : RenderingTest() {
     """)
 
     @Test
+    fun truncateNoWrap() = doTestNoWrap(OverflowWrap.TRUNCATE, """
+        ░The weather today is 21
+        ░Llanfairpwllgwyngyllgog
+    """)
+
+    @Test
     fun ellipses() = doTest(OverflowWrap.ELLIPSES, """
         ░The weather today is
         ░21°C in
+        ░Llanfairpwllgwyngyllgo…
+    """)
+
+
+    @Test
+    fun ellipsesNoWrap() = doTestNoWrap(OverflowWrap.ELLIPSES, """
+        ░The weather today is 2…
         ░Llanfairpwllgwyngyllgo…
     """)
 
@@ -44,6 +57,19 @@ class TextOverflowWrapTest : RenderingTest() {
         checkRender(Text(
             text,
             whitespace = Whitespace.NORMAL,
+            align = TextAlign.NONE,
+            overflowWrap = wrap
+        ), expected, width = 23)
+    }
+
+    private fun doTestNoWrap(wrap: OverflowWrap, expected: String) {
+        val text = """
+        ░The weather today is 21°C in
+        ░Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch
+        """.trimMargin("░")
+        checkRender(Text(
+            text,
+            whitespace = Whitespace.NOWRAP,
             align = TextAlign.NONE,
             overflowWrap = wrap
         ), expected, width = 23)


### PR DESCRIPTION
Hi 👋 

I noticed that text was not consistently truncated when using the `NOWRAP` whitespace configuration. Truncation would only happen if the span/word was longer than the terminal width.

Don't know if I added the tests in the right place but at least they demonstrate the issue.

