### PR TITLE
replace use of Terminal::printMarkdown in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ terminal that supports it, like recent versions of iTerm or Windows Terminal.
 
 ```kotlin
 val t = Terminal()
-t.printMarkdown(File("README.md").readText())
+t.print(Markdown(Path("README.md").readText()))
 ```
 
 ![](docs/img/markdown.png)


### PR DESCRIPTION
with print and Markdown widget, because printMarkdown was removed in  47f0514a5a04e3cf79025b7deb035ea17e374b24.

I also took the liberty to replace File with Path, since the latter is generally recommended.