### PR TITLE
Make the "table" sample work with the Gradle application plugin

### DIFF
--- a/samples/table/build.gradle.kts
+++ b/samples/table/build.gradle.kts
@@ -6,7 +6,10 @@ plugins {
 }
 
 kotlin {
-    jvm()
+    jvm {
+        withJava()
+    }
+
     macosX64()
     linuxX64()
     mingwX64()


### PR DESCRIPTION
Previously, the "table.jar" generated for distribution was empty besides a "META-INF" directory. For background information see

https://youtrack.jetbrains.com/issue/KT-37964