### PR TITLE
Add workarounds for new KMP warnings

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/internal/HyperlinkIds.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/internal/HyperlinkIds.kt
@@ -1,7 +1,7 @@
 package com.github.ajalt.mordant.internal
 
 
-private val nextHyperlinkId = AtomicInt(1)
+private val nextHyperlinkId = MppAtomicInt(1)
 
 internal fun generateHyperlinkId(): String {
     return nextHyperlinkId.getAndIncrement().toString()

--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/internal/MppH.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/internal/MppH.kt
@@ -2,11 +2,13 @@ package com.github.ajalt.mordant.internal
 
 import com.github.ajalt.mordant.terminal.*
 
-internal expect class AtomicInt(initial: Int) {
+internal interface MppAtomicInt {
     fun getAndIncrement(): Int
     fun get(): Int
     fun set(value: Int)
 }
+
+internal expect fun MppAtomicInt(initial: Int): MppAtomicInt
 
 internal expect fun getEnv(key: String): String?
 

--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/widgets/Spinner.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/widgets/Spinner.kt
@@ -1,6 +1,6 @@
 package com.github.ajalt.mordant.widgets
 
-import com.github.ajalt.mordant.internal.AtomicInt
+import com.github.ajalt.mordant.internal.MppAtomicInt
 import com.github.ajalt.mordant.internal.DEFAULT_STYLE
 import com.github.ajalt.mordant.rendering.Lines
 import com.github.ajalt.mordant.rendering.TextStyle
@@ -54,7 +54,7 @@ class Spinner(
     constructor(frames: String, style: TextStyle = DEFAULT_STYLE, duration: Int = 1, initial: Int = 0) :
             this(frames.map { Text(style(it.toString())) }, duration, initial)
 
-    private val _tick = AtomicInt(initial)
+    private val _tick = MppAtomicInt(initial)
 
     /**
      * The current frame number.

--- a/mordant/src/jsMain/kotlin/com/github/ajalt/mordant/internal/MppImpl.kt
+++ b/mordant/src/jsMain/kotlin/com/github/ajalt/mordant/internal/MppImpl.kt
@@ -7,20 +7,22 @@ private external val console: dynamic
 private external val Symbol: dynamic
 private external val Buffer: dynamic
 
-internal actual class AtomicInt actual constructor(initial: Int) {
+private class JsAtomicInt(initial: Int) : MppAtomicInt{
     private var backing = initial
-    actual fun getAndIncrement(): Int {
+    override fun getAndIncrement(): Int {
         return backing++
     }
 
-    actual fun get(): Int {
+    override fun get(): Int {
         return backing
     }
 
-    actual fun set(value: Int) {
+    override fun set(value: Int) {
         backing = value
     }
 }
+
+internal actual fun MppAtomicInt(initial: Int): MppAtomicInt = JsAtomicInt(initial)
 
 
 private interface JsMppImpls {

--- a/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppImpl.kt
+++ b/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppImpl.kt
@@ -9,20 +9,22 @@ import com.github.ajalt.mordant.terminal.*
 import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicInteger
 
-internal actual class AtomicInt actual constructor(initial: Int) {
+private class JvmAtomicInt(initial: Int): MppAtomicInt {
     private val backing = AtomicInteger(initial)
-    actual fun getAndIncrement(): Int {
+    override fun getAndIncrement(): Int {
         return backing.getAndIncrement()
     }
 
-    actual fun get(): Int {
+    override fun get(): Int {
         return backing.get()
     }
 
-    actual fun set(value: Int) {
+    override fun set(value: Int) {
         backing.set(value)
     }
 }
+
+internal actual fun MppAtomicInt(initial: Int): MppAtomicInt = JvmAtomicInt(initial)
 
 internal actual fun getEnv(key: String): String? = System.getenv(key)
 

--- a/mordant/src/posixMain/kotlin/com/github/ajalt/mordant/internal/tty.kt
+++ b/mordant/src/posixMain/kotlin/com/github/ajalt/mordant/internal/tty.kt
@@ -6,6 +6,7 @@ import kotlinx.cinterop.*
 import platform.posix.*
 
 // https://www.gnu.org/software/libc/manual/html_node/getpass.html
+@OptIn(UnsafeNumber::class) // https://youtrack.jetbrains.com/issue/KT-60572
 internal actual fun ttySetEcho(echo: Boolean) = memScoped {
     val termios = alloc<termios>()
     if (tcgetattr(STDOUT_FILENO, termios.ptr) != 0) {


### PR DESCRIPTION
Kotlin 1.9.20 added some new restrictions on MPP code.