### PR TITLE
Add browser-specific implementation of TerminalCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Vertical layout now correctly pads non-text cells when `align` is set to `TextAlign.LEFT`
+- Fixed exception when hiding the cursor on browsers on JS target.
 
 ## 2.3.0
 ### Added


### PR DESCRIPTION
The existing JS implementation is referencing a node-only API for its shutdown hook.