### PR TITLE
Support raw mode for posix in native image

### DIFF
--- a/test/graalvm/src/test/kotlin/GraalSmokeTest.kt
+++ b/test/graalvm/src/test/kotlin/GraalSmokeTest.kt
@@ -39,15 +39,6 @@ class GraalSmokeTest {
         future.get(1000, TimeUnit.MILLISECONDS)
     }
 
-    @Ignore("Raw mode is currently unsupported on native-image")
-    @Test
-    fun `raw mode test`() {
-        val t = Terminal(interactive = true)
-        assertThrows<RuntimeException> {
-            t.enterRawMode().use {}
-        }
-    }
-
     @Test
     fun `markdown test`() {
         val vt = TerminalRecorder()


### PR DESCRIPTION
The issue with `Expected Object but got Word` when compiling the native image comes from the fact that the kotlin compiler insert null checks if the used types are not nullable.

For example, if we declare tcgetattr as

```kotlin
@CFunction("tcgetattr")
external fun tcgetattr(fd: Int, termios: termios): Int
```

Every call to it will be compiled as

```kotlin
Intrinsics.checkNotNull(termios);
tcgetattr(..., termios);
```

It is possible to disable those checks with the following compiler parameters:
-Xno-param-assertions, -Xno-call-assertions,-Xno-receiver-assertions.

But in this case, it is enough to simply mark the termios parameter as nullable.