### PR TITLE
Prevent error with musl libc and GraalVM native image

### DIFF
--- a/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/syscalls/nativeimage/SyscallHandler.nativeimage.linux.kt
+++ b/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/syscalls/nativeimage/SyscallHandler.nativeimage.linux.kt
@@ -42,7 +42,7 @@ private object LinuxLibC {
         val ws_col: Short
     }
 
-    @CStruct("termios", addStructKeyword = true)
+    @CStruct("termios", addStructKeyword = true, isIncomplete = true)
     interface termios : PointerBase {
         @get:CField("c_iflag")
         @set:CField("c_iflag")
@@ -67,13 +67,9 @@ private object LinuxLibC {
         @get:CFieldAddress("c_cc")
         val c_cc: CCharPointer
 
-        @get:CField("c_ispeed")
-        @set:CField("c_ispeed")
-        var c_ispeed: Int
-
-        @get:CField("c_ospeed")
-        @set:CField("c_ospeed")
-        var c_ospeed: Int
+        companion object {
+            const val STRUCT_SIZE = 60
+        }
     }
 
     @CFunction("isatty")
@@ -104,7 +100,7 @@ internal class SyscallHandlerNativeImageLinux : SyscallHandlerJvmPosix() {
     }
 
     override fun getStdinTermios(): Termios {
-        val termios = StackValue.get(LinuxLibC.termios::class.java)
+        val termios = StackValue.get<LinuxLibC.termios>(LinuxLibC.termios.STRUCT_SIZE)
         if (LinuxLibC.tcgetattr(STDIN_FILENO, termios) != 0) {
             throw RuntimeException("Error reading terminal attributes")
         }
@@ -118,7 +114,7 @@ internal class SyscallHandlerNativeImageLinux : SyscallHandlerJvmPosix() {
     }
 
     override fun setStdinTermios(termios: Termios) {
-        val nativeTermios = StackValue.get(LinuxLibC.termios::class.java)
+        val nativeTermios = StackValue.get<LinuxLibC.termios>(LinuxLibC.termios.STRUCT_SIZE)
         if (LinuxLibC.tcgetattr(STDIN_FILENO, nativeTermios) != 0) {
             throw RuntimeException("Error reading terminal attributes")
         }


### PR DESCRIPTION
When compiling a native image for linux with musl libc, the following error was displayed:
`'struct termios' has no member named 'c_ispeed'`

On musl, it is named `__c_ispeed`

Since we don't really need those fields anyway,
we can remove them from the struct definition.

We then need to mark the struct definition as incomplete. The documentation says:
If marked as incomplete, we will not try to determine the size of the struct.

`StackValue.get(structType)` is actually a shortcut for `StackValue.get(SizeOf.get(structType))`

We now simply need to pass the explicit size in bytes.

Fixes https://github.com/ajalt/mordant/issues/189