### PR TITLE
Fix native image support

### DIFF
--- a/mordant-jvm-ffm/api/mordant-jvm-ffm.api
+++ b/mordant-jvm-ffm/api/mordant-jvm-ffm.api
@@ -1,11 +1,11 @@
-public abstract class com/github/ajalt/mordant/terminal/terminalinterface/MethodHandlesHolder {
+public abstract class com/github/ajalt/mordant/terminal/terminalinterface/ffm/MethodHandlesHolder {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/foreign/Linker;Ljava/lang/foreign/SymbolLookup;)V
 	public synthetic fun <init> (Ljava/lang/foreign/Linker;Ljava/lang/foreign/SymbolLookup;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun handle (Ljava/lang/foreign/MemoryLayout;[Ljava/lang/foreign/MemoryLayout;)Lkotlin/properties/PropertyDelegateProvider;
 }
 
-public final class com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProviderFfm : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
+public final class com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterfaceProviderFfm : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
 	public fun <init> ()V
 	public fun load ()Lcom/github/ajalt/mordant/terminal/TerminalInterface;
 }

--- a/mordant-jvm-ffm/build.gradle.kts
+++ b/mordant-jvm-ffm/build.gradle.kts
@@ -9,5 +9,8 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":mordant"))
         }
+        jvmMain.dependencies {
+            compileOnly(libs.graalvm.svm)
+        }
     }
 }

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.ffm.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.ffm.kt
@@ -2,6 +2,8 @@ package com.github.ajalt.mordant.terminal.terminalinterface
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+import com.oracle.svm.core.annotate.Substitute
+import com.oracle.svm.core.annotate.TargetClass
 
 class TerminalInterfaceProviderFfm : TerminalInterfaceProvider {
     override fun load(): TerminalInterface? {
@@ -16,4 +18,12 @@ class TerminalInterfaceProviderFfm : TerminalInterfaceProvider {
             else -> null
         }
     }
+}
+
+@TargetClass(TerminalInterfaceProviderFfm::class)
+private class TerminalInterfaceProviderFfmNative {
+
+    @Substitute
+    fun load(): TerminalInterface? = null
+
 }

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/FfmLayouts.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/FfmLayouts.kt
@@ -1,4 +1,4 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.ffm
 
 import java.lang.foreign.*
 import java.lang.foreign.MemoryLayout.PathElement

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterface.ffm.macos.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterface.ffm.macos.kt
@@ -1,11 +1,12 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.ffm
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceJvmPosix
 import java.lang.foreign.Arena
 import java.lang.foreign.MemorySegment
 
 @Suppress("ClassName", "PropertyName", "SpellCheckingInspection")
-private class LinuxCLibrary {
+private class MacosCLibrary {
     class winsize(override val segment: MemorySegment) : StructAccessor {
         object Layout : StructLayout() {
             val ws_row by shortField()
@@ -24,16 +25,11 @@ private class LinuxCLibrary {
 
     class termios(override val segment: MemorySegment) : StructAccessor {
         object Layout : StructLayout() {
-            val c_iflag by intField()
-            val c_oflag by intField()
-            val c_cflag by intField()
-            val c_lflag by intField()
-            val c_line by byteField()
+            val c_iflag by longField()
+            val c_oflag by longField()
+            val c_cflag by longField()
+            val c_lflag by longField()
             val c_cc by arrayField(32)
-            @Suppress("unused")
-            val padding by paddingField(3)
-            val c_ispeed by intField()
-            val c_ospeed by intField()
         }
 
         constructor(arena: Arena) : this(arena.allocate(Layout.layout))
@@ -42,10 +38,7 @@ private class LinuxCLibrary {
         var c_oflag by Layout.c_oflag
         var c_cflag by Layout.c_cflag
         var c_lflag by Layout.c_lflag
-        var c_line by Layout.c_line
         val c_cc by Layout.c_cc
-        var c_ispeed by Layout.c_ispeed
-        var c_ospeed by Layout.c_ospeed
     }
 
     object MethodHandles : MethodHandlesHolder() {
@@ -72,19 +65,19 @@ private class LinuxCLibrary {
     }
 }
 
-internal class TerminalInterfaceFfmLinux : TerminalInterfaceJvmPosix() {
-    override val termiosConstants: TermiosConstants get() = LinuxTermiosConstants
+internal class TerminalInterfaceFfmMacos : TerminalInterfaceJvmPosix() {
+    override val termiosConstants: TermiosConstants get() = MacosTermiosConstants
 
     private companion object {
         const val TIOCGWINSZ = 0x00005413
         const val TCSADRAIN: Int = 0x1
     }
 
-    private val libC = LinuxCLibrary()
+    private val libC = MacosCLibrary()
     override fun isatty(fd: Int): Boolean = libC.isatty(fd)
 
     override fun getTerminalSize(): Size? = Arena.ofConfined().use { arena ->
-        val size = LinuxCLibrary.winsize(arena)
+        val size = MacosCLibrary.winsize(arena)
         if (!libC.ioctl(STDIN_FILENO, TIOCGWINSZ, size.segment)) {
             null
         } else {
@@ -93,7 +86,7 @@ internal class TerminalInterfaceFfmLinux : TerminalInterfaceJvmPosix() {
     }
 
     override fun getStdinTermios(): Termios = Arena.ofConfined().use { arena ->
-        val termios = LinuxCLibrary.termios(arena)
+        val termios = MacosCLibrary.termios(arena)
         if (!libC.tcgetattr(STDIN_FILENO, termios)) {
             throw RuntimeException("failed to read terminal settings")
         }
@@ -107,14 +100,14 @@ internal class TerminalInterfaceFfmLinux : TerminalInterfaceJvmPosix() {
     }
 
     override fun setStdinTermios(termios: Termios): Unit = Arena.ofConfined().use { arena ->
-        val nativeTermios = LinuxCLibrary.termios(arena)
+        val nativeTermios = MacosCLibrary.termios(arena)
         if (!libC.tcgetattr(STDIN_FILENO, nativeTermios)) {
             throw RuntimeException("failed to update terminal settings")
         }
-        nativeTermios.c_iflag = termios.iflag.toInt()
-        nativeTermios.c_oflag = termios.oflag.toInt()
-        nativeTermios.c_cflag = termios.cflag.toInt()
-        nativeTermios.c_lflag = termios.lflag.toInt()
+        nativeTermios.c_iflag = termios.iflag.toLong()
+        nativeTermios.c_oflag = termios.oflag.toLong()
+        nativeTermios.c_cflag = termios.cflag.toLong()
+        nativeTermios.c_lflag = termios.lflag.toLong()
         nativeTermios.c_cc.copyFrom(MemorySegment.ofArray(termios.cc))
         libC.tcsetattr(STDIN_FILENO, TCSADRAIN, nativeTermios)
     }

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterface.ffm.windows.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterface.ffm.windows.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.ffm
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceWindows
 import java.lang.foreign.*
 
 private object WinLayouts {

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterfaceProvider.ffm.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterfaceProvider.ffm.kt
@@ -1,4 +1,4 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.ffm
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider

--- a/mordant-jvm-ffm/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-ffm/native-image.properties
+++ b/mordant-jvm-ffm/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-ffm/native-image.properties
@@ -1,3 +1,0 @@
-Args = -H:+UnlockExperimentalVMOptions \
-       -H:ResourceConfigurationResources=${.}/resource-config.json \
-       -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/mordant-jvm-ffm/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+++ b/mordant-jvm-ffm/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
@@ -1,1 +1,1 @@
-com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderFfm
+com.github.ajalt.mordant.terminal.terminalinterface.ffm.TerminalInterfaceProviderFfm

--- a/mordant-jvm-graal-ffi/api/mordant-jvm-graal-ffi.api
+++ b/mordant-jvm-graal-ffi/api/mordant-jvm-graal-ffi.api
@@ -1,4 +1,4 @@
-public final class com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProviderNativeImage : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
+public final class com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterfaceProviderNativeImage : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
 	public fun <init> ()V
 	public fun load ()Lcom/github/ajalt/mordant/terminal/TerminalInterface;
 }

--- a/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.nativeimage.kt
+++ b/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.nativeimage.kt
@@ -2,20 +2,38 @@ package com.github.ajalt.mordant.terminal.terminalinterface
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+import com.oracle.svm.core.annotate.Substitute
+import com.oracle.svm.core.annotate.TargetClass
+import org.graalvm.nativeimage.Platform
+import org.graalvm.nativeimage.Platforms
 
 class TerminalInterfaceProviderNativeImage : TerminalInterfaceProvider {
-    override fun load(): TerminalInterface? {
-        // Inlined version of ImageInfo.inImageCode()
-        val imageCode = System.getProperty("org.graalvm.nativeimage.imagecode")
-        val isNativeImage = imageCode == "buildtime" || imageCode == "runtime"
-        if (!isNativeImage) return null
+    override fun load(): TerminalInterface? = null
+}
 
-        val os = System.getProperty("os.name")
-        return when {
-            os.startsWith("Windows") -> TerminalInterfaceNativeImageWindows()
-            os == "Linux" -> TerminalInterfaceNativeImageLinux()
-            os == "Mac OS X" -> TerminalInterfaceNativeImageMacos()
-            else -> null
-        }
-    }
+@Platforms(Platform.LINUX::class)
+@TargetClass(TerminalInterfaceProviderNativeImage::class)
+private class TerminalInterfaceProviderNativeImageLinux {
+
+    @Substitute
+    fun load(): TerminalInterface = TerminalInterfaceNativeImageLinux()
+
+}
+
+@Platforms(Platform.WINDOWS::class)
+@TargetClass(TerminalInterfaceProviderNativeImage::class)
+private class TerminalInterfaceProviderNativeImageWindows {
+
+    @Substitute
+    fun load(): TerminalInterface = TerminalInterfaceNativeImageWindows()
+
+}
+
+@Platforms(Platform.MACOS::class)
+@TargetClass(TerminalInterfaceProviderNativeImage::class)
+private class TerminalInterfaceProviderNativeImageMacos {
+
+    @Substitute
+    fun load(): TerminalInterface = TerminalInterfaceNativeImageMacos()
+
 }

--- a/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.linux.kt
+++ b/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.linux.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.nativeimage
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceJvmPosix
 import org.graalvm.nativeimage.Platform
 import org.graalvm.nativeimage.Platforms
 import org.graalvm.nativeimage.StackValue

--- a/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.macos.kt
+++ b/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.macos.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.nativeimage
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceJvmPosix
 import org.graalvm.nativeimage.Platform
 import org.graalvm.nativeimage.Platforms
 import org.graalvm.nativeimage.StackValue

--- a/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.windows.kt
+++ b/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterface.nativeimage.windows.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.nativeimage
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceWindows
 import org.graalvm.nativeimage.Platform
 import org.graalvm.nativeimage.Platforms
 import org.graalvm.nativeimage.StackValue

--- a/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterfaceProvider.nativeimage.kt
+++ b/mordant-jvm-graal-ffi/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/nativeimage/TerminalInterfaceProvider.nativeimage.kt
@@ -1,4 +1,4 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.nativeimage
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider

--- a/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-graal-ffi/native-image.properties
+++ b/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-graal-ffi/native-image.properties
@@ -1,3 +1,0 @@
-Args = -H:+UnlockExperimentalVMOptions \
-       -H:ResourceConfigurationResources=${.}/resource-config.json \
-       -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-graal-ffi/native-image.properties
+++ b/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-graal-ffi/native-image.properties
@@ -1,11 +1,3 @@
 Args = -H:+UnlockExperimentalVMOptions \
        -H:ResourceConfigurationResources=${.}/resource-config.json \
-       -H:ReflectionConfigurationResources=${.}/reflection-config.json \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfacePosix$Companion \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfacePosix$TermiosConstants \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderNativeImage \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceNativeImageLinux \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceNativeImageMacos \
-       --initialize-at-build-time=com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceNativeImageWindows \
-       --initialize-at-build-time=com.github.ajalt.mordant.internal.MppInternal_jvmKt \
-       --initialize-at-build-time=com.github.ajalt.mordant.internal.MppInternalKt
+       -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+++ b/mordant-jvm-graal-ffi/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
@@ -1,1 +1,1 @@
-com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderNativeImage
+com.github.ajalt.mordant.terminal.terminalinterface.nativeimage.TerminalInterfaceProviderNativeImage

--- a/mordant-jvm-jna/api/mordant-jvm-jna.api
+++ b/mordant-jvm-jna/api/mordant-jvm-jna.api
@@ -1,4 +1,4 @@
-public final class com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProviderJna : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
+public final class com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterfaceProviderJna : com/github/ajalt/mordant/terminal/TerminalInterfaceProvider {
 	public fun <init> ()V
 	public fun load ()Lcom/github/ajalt/mordant/terminal/TerminalInterface;
 }

--- a/mordant-jvm-jna/build.gradle.kts
+++ b/mordant-jvm-jna/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         }
         jvmMain.dependencies {
             implementation(libs.jna.core)
+            compileOnly(libs.graalvm.svm)
         }
     }
 }

--- a/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.jna.kt
+++ b/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterfaceProvider.jna.kt
@@ -2,6 +2,8 @@ package com.github.ajalt.mordant.terminal.terminalinterface
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+import com.oracle.svm.core.annotate.Substitute
+import com.oracle.svm.core.annotate.TargetClass
 
 class TerminalInterfaceProviderJna : TerminalInterfaceProvider {
     override fun load(): TerminalInterface? {
@@ -22,4 +24,12 @@ class TerminalInterfaceProviderJna : TerminalInterfaceProvider {
             null
         }
     }
+}
+
+@TargetClass(TerminalInterfaceProviderJna::class)
+private class TerminalInterfaceProviderJnaNative {
+
+    @Substitute
+    fun load(): TerminalInterface? = null
+
 }

--- a/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.linux.kt
+++ b/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.linux.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.jna
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceJvmPosix
 import com.sun.jna.*
 
 @Suppress("ClassName", "PropertyName", "MemberVisibilityCanBePrivate", "SpellCheckingInspection")

--- a/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.macos.kt
+++ b/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.macos.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.jna
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceJvmPosix
 import com.sun.jna.*
 import java.io.IOException
 import java.util.concurrent.TimeUnit

--- a/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.windows.kt
+++ b/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterface.jna.windows.kt
@@ -1,6 +1,7 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.jna
 
 import com.github.ajalt.mordant.rendering.Size
+import com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceWindows
 import com.sun.jna.*
 import com.sun.jna.ptr.IntByReference
 import com.sun.jna.win32.W32APIOptions

--- a/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterfaceProvider.jna.kt
+++ b/mordant-jvm-jna/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/jna/TerminalInterfaceProvider.jna.kt
@@ -1,4 +1,4 @@
-package com.github.ajalt.mordant.terminal.terminalinterface
+package com.github.ajalt.mordant.terminal.terminalinterface.jna
 
 import com.github.ajalt.mordant.terminal.TerminalInterface
 import com.github.ajalt.mordant.terminal.TerminalInterfaceProvider

--- a/mordant-jvm-jna/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-jna/native-image.properties
+++ b/mordant-jvm-jna/src/jvmMain/resources/META-INF/native-image/com.github.ajalt.mordant/mordant-jvm-jna/native-image.properties
@@ -1,3 +1,0 @@
-Args = -H:+UnlockExperimentalVMOptions \
-       -H:ResourceConfigurationResources=${.}/resource-config.json \
-       -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/mordant-jvm-jna/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
+++ b/mordant-jvm-jna/src/jvmMain/resources/META-INF/services/com.github.ajalt.mordant.terminal.TerminalInterfaceProvider
@@ -1,1 +1,1 @@
-com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderJna
+com.github.ajalt.mordant.terminal.terminalinterface.jna.TerminalInterfaceProviderJna

--- a/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppInternal.jvm.kt
+++ b/mordant/src/jvmMain/kotlin/com/github/ajalt/mordant/internal/MppInternal.jvm.kt
@@ -127,9 +127,9 @@ internal actual fun getStandardTerminalInterface(): TerminalInterface {
         .associateBy { it::class.qualifiedName }
     // The built-in providers in the order that they should be loaded
     val builtins = listOf(
-        "com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderFfm",
-        "com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderNativeImage",
-        "com.github.ajalt.mordant.terminal.terminalinterface.TerminalInterfaceProviderJna",
+        "com.github.ajalt.mordant.terminal.terminalinterface.ffm.TerminalInterfaceProviderFfm",
+        "com.github.ajalt.mordant.terminal.terminalinterface.nativeimage.TerminalInterfaceProviderNativeImage",
+        "com.github.ajalt.mordant.terminal.terminalinterface.jna.TerminalInterfaceProviderJna",
     )
 
     // All providers, including user-provided ones

--- a/mordant/src/jvmMain/resources/com.github.ajalt.mordant/mordant-core/native-image.properties
+++ b/mordant/src/jvmMain/resources/com.github.ajalt.mordant/mordant-core/native-image.properties
@@ -1,1 +1,0 @@
-Args = --initialize-at-build-time=com.github.ajalt.mordant.internal.MppInternal_jvmKt,com.github.ajalt.mordant.internal.MppInternalKt

--- a/test/graalvm/src/test/kotlin/GraalSmokeTest.kt
+++ b/test/graalvm/src/test/kotlin/GraalSmokeTest.kt
@@ -11,6 +11,7 @@ import com.github.ajalt.mordant.widgets.progress.progressBar
 import com.github.ajalt.mordant.widgets.progress.progressBarLayout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledInNativeImage
 import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
@@ -19,13 +20,16 @@ import kotlin.test.fail
  *
  * They just make sure nothing crashes; the actual output is verified in the normal test suite.
  */
+@EnabledInNativeImage
 class GraalSmokeTest {
-    // It would be nice to have more graal-specific assertions, but the nativeTest task actually
-    // runs all the tests twice, the first time on regular JVM to detect tests, then a second time
-    // on native. So any assertions about environment would have to handle that.
     @Test
     fun `terminal detection test`() {
+        val name = Terminal().terminalInterface::class.simpleName
         Terminal()
+        val assertion = name!!.startsWith("TerminalInterfaceNativeImage")
+        if (!assertion) {
+            fail("Incorrect terminal interface: $name")
+        }
     }
 
     @Test


### PR DESCRIPTION
This should solve GraalVM native image issues. See commits for details.

I tried the select sample and a personal project locally on linux X64 using
- native image 22.0.2-graal
- native image 21.0.4-graal
- JVM 21.0.4-graal
- JVM 22.0.2-graal
- JVM 17.0.10-tem
- JVM 11.0.22-tem
- JVM 8.0.402-tem

With Java 8, it fails

```
Exception in thread "main" java.lang.NoSuchMethodError: java.lang.Class.getModule()Ljava/lang/Module;
	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.TerminalInterfaceProviderFfm.load(TerminalInterfaceProvider.ffm.kt:10)
	at com.github.ajalt.mordant.internal.MppInternal_jvmKt.getStandardTerminalInterface(MppInternal.jvm.kt:139)
	at com.github.ajalt.mordant.internal.MppInternalKt.<clinit>(MppInternal.kt:60)
	at com.github.ajalt.mordant.terminal.Terminal.<init>(Terminal.kt:49)
	at com.github.ajalt.mordant.samples.MainKt.main(main.kt:9)
	at com.github.ajalt.mordant.samples.MainKt.main(main.kt)
```

And with java 11 and 17

```
Exception in thread "main" java.lang.NoSuchMethodError: 'boolean java.lang.Module.isNativeAccessEnabled()'
	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.TerminalInterfaceProviderFfm.load(TerminalInterfaceProvider.ffm.kt:10)
	at com.github.ajalt.mordant.internal.MppInternal_jvmKt.getStandardTerminalInterface(MppInternal.jvm.kt:139)
	at com.github.ajalt.mordant.internal.MppInternalKt.<clinit>(MppInternal.kt:60)
	at com.github.ajalt.mordant.terminal.Terminal.<init>(Terminal.kt:49)
	at com.github.ajalt.mordant.samples.MainKt.main(main.kt:9)
	at com.github.ajalt.mordant.samples.MainKt.main(main.kt)
```

I'm assuming this can be solved using a multi release jar (or a try catch :thinking:). 

A few more things I noticed,

- I had to rebuild libraries depending on mordant, notably clikt due to the new Terminal constructor, it is no longer binary compatible.

- MethodHandlesHolder is public, but maybe it shouldn't be