### PR TITLE
Use raw pointers for graal union struct

### DIFF
--- a/mordant-jvm-graal-ffi/build.gradle.kts
+++ b/mordant-jvm-graal-ffi/build.gradle.kts
@@ -13,4 +13,11 @@ kotlin {
             compileOnly(libs.graalvm.svm)
         }
     }
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xno-param-assertions",
+            "-Xno-call-assertions",
+            "-Xno-receiver-assertions",
+        )
+    }
 }


### PR DESCRIPTION
I tried to use @RawFieldStructure to define the different union subtypes, but for some reasons, the offsets were not properly computed. This goal was to use pointer.readWord<KeyEventRecord>().

We can check the offsets using @RawFieldOffset.

For example this was the definition of KeyEventRecord

```kotlin
@RawStructure
interface KeyEventRecord extends PointerBase {

    @RawField
    void setBKeyDown(boolean value);

    @RawField
    boolean getBKeyDown();

    @RawFieldOffset
    static int offsetOfBKeyDown() {
        return -1;
    }

    @RawField
    void setWRepeatCount(short value);

    @RawField
    short getWRepeatCount();

    @RawFieldOffset
    static int offsetOfWRepeatCount() {
        return -1;
    }

    @RawField
    void setWVirtualKeyCode(short value);

    @RawField
    short getWVirtualKeyCode();

    @RawFieldOffset
    static int offsetOfWVirtualKeyCode() {
        return -1;
    }

    @RawField
    void setWVirtualScanCode(short value);

    @RawField
    short getWVirtualScanCode();

    @RawFieldOffset
    static int offsetOfWVirtualScanCode() {
        return -1;
    }

    @RawField
    void setUChar(char value);

    @RawField
    char getUChar();

    @RawFieldOffset
    static int offsetOfUChar() {
        return -1;
    }

    @RawField
    void setDwControlKeyState(int value);

    @RawField
    int getDwControlKeyState();

    @RawFieldOffset
    static int offsetOfDwControlKeyState() {
        return -1;
    }
}
```

For some reason, the offsets were all over the place. (Maybe I misundestood the API)
I thus used the Pointer directly. Thanks to the ffm implementation, it was easy the get the correct offsets and byte sizes.