### PR TITLE
Improve performance of progress bars under high concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - Removed constructor overloads for `Terminal`. There is now one constructor with all default parameters. 
 
 ### Fixed
-- Fixed ConcurrentModificationException from progress bars when updated under very high concurrency [(#240)](https://github.com/ajalt/mordant/issues/240)
+- Fixed ConcurrentModificationException from progress bars when updated under very high concurrency [(#204)](https://github.com/ajalt/mordant/issues/204)
+- Improved performance of progress bars under high concurrency. [(#207)](https://github.com/ajalt/mordant/issues/207)
 
 ## 2.7.2
 ### Fixed


### PR DESCRIPTION
Keeping track of progress history was taking a lot of CPU load if updates were happening very frequently. 

@aSemy suggested an improvement in https://github.com/ajalt/mordant/issues/204#issuecomment-2295274887, and this PR goes further:

Instead of keeping a list with an entry for each call to `update`, we instead keep a fixed size list, and overwrite the last entry if it was very recent. We only look at the first and last entries to calculate speed, so there's no need to keep every entry.

```
Benchmark                        Mode  Cnt      Score      Error  Units
JmhBenchmark.benchmarkCurrent    avgt    3  34931.106 ± 1299.242  ns/op
JmhBenchmark.benchmarkAsemy      avgt    3   5474.108 ±  634.242  ns/op
JmhBenchmark.benchmarkFixedList  avgt    3    176.047 ±   53.293  ns/op
```

This change is a 350x speedup on the benchmarks I ran, which seems fast enough.

Fixes #207