### PR TITLE
Proof of concept decouple Gradle JDK from compiling JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 22
+          java-version: 17
       - uses: gradle/actions/setup-gradle@v3
       - name: Run tests
         run: >-

--- a/mordant-jvm-ffm/build.gradle.kts
+++ b/mordant-jvm-ffm/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 kotlin {
     jvm()
+    jvmToolchain(22)
     sourceSets {
         commonMain.dependencies {
             implementation(project(":mordant"))

--- a/mordant/api/mordant.api
+++ b/mordant/api/mordant.api
@@ -436,10 +436,6 @@ public final class com/github/ajalt/mordant/rendering/Line : java/util/List, kot
 	public synthetic fun add (Ljava/lang/Object;)Z
 	public fun addAll (ILjava/util/Collection;)Z
 	public fun addAll (Ljava/util/Collection;)Z
-	public fun addFirst (Lcom/github/ajalt/mordant/rendering/Span;)V
-	public synthetic fun addFirst (Ljava/lang/Object;)V
-	public fun addLast (Lcom/github/ajalt/mordant/rendering/Span;)V
-	public synthetic fun addLast (Ljava/lang/Object;)V
 	public fun clear ()V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lcom/github/ajalt/mordant/rendering/TextStyle;
@@ -467,10 +463,6 @@ public final class com/github/ajalt/mordant/rendering/Line : java/util/List, kot
 	public synthetic fun remove (I)Ljava/lang/Object;
 	public fun remove (Ljava/lang/Object;)Z
 	public fun removeAll (Ljava/util/Collection;)Z
-	public fun removeFirst ()Lcom/github/ajalt/mordant/rendering/Span;
-	public synthetic fun removeFirst ()Ljava/lang/Object;
-	public fun removeLast ()Lcom/github/ajalt/mordant/rendering/Span;
-	public synthetic fun removeLast ()Ljava/lang/Object;
 	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
 	public fun retainAll (Ljava/util/Collection;)Z
 	public fun set (ILcom/github/ajalt/mordant/rendering/Span;)Lcom/github/ajalt/mordant/rendering/Span;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,3 +33,7 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}

--- a/test/proguard/build.gradle.kts
+++ b/test/proguard/build.gradle.kts
@@ -51,6 +51,11 @@ val r8JarProvider by tasks.register<JavaExec>("r8Jar") {
     inputs.files(fatJarFile, rulesFile)
     outputs.file(r8File)
 
+    javaLauncher = javaToolchains.launcherFor { 
+        languageVersion.set(JavaLanguageVersion.of(22))
+        vendor = JvmVendorSpec.AZUL // Zulu
+    }
+
     classpath(r8)
     mainClass.set("com.android.tools.r8.R8")
     args = listOf(


### PR DESCRIPTION
Note:
 * Gradle 8.x supports 8-23 for running Gradle
 * Gradle 9.x scheduled to support 17-23 for running Gradle

https://docs.gradle.org/current/userguide/compatibility.html

I ran the CI here: https://github.com/TWiStErRob/mordant/pull/1 (https://github.com/TWiStErRob/mordant/actions/runs/11092440186)

This enables developers (contributors) to have almost any JDK they want, not just 22/23.

Feel free to close this if you're not interested, it just came out of me trying to build the project and investigate my issues.