### PR TITLE
fix(MultiProgressBarAnimation.kt): startTime

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/animation/progress/MultiProgressBarAnimation.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/animation/progress/MultiProgressBarAnimation.kt
@@ -180,7 +180,7 @@ private class ProgressTaskImpl<T>(
             )
             val total = scope.total
 
-            val startTime = status.pauseTime ?: now
+            val startTime = status.startTime ?: now
             val finishTime = status.finishTime ?: now
             val pauseTime = status.pauseTime ?: now
 


### PR DESCRIPTION
## Fix: Correct startTime Initialization in ProgressTaskImpl

### Summary

This PR fixes an issue where startTime was incorrectly set to pauseTime, ensuring accurate task progress tracking and speed estimation.

### Changes

Updated:
```kotlin
val startTime = status.pauseTime ?: now
```
to: 
```kotlin
val startTime = status.startTime ?: now
```