### PR TITLE
Smoke test mordant against Java LTS releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,15 +53,54 @@ jobs:
             :mordant-markdown:check
             :test:graalvm:nativeTest
             --stacktrace
-      - name: Run R8 Jar
+
+      - name: Upload R8 Jar
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: java -jar test/proguard/build/libs/main-r8.jar
+        uses: actions/upload-artifact@v5
+        with:
+          name: main-r8-jar
+          path: 'test/proguard/build/libs/main-r8.jar'
+          retention-days: 1
+
       - name: Upload the build report
         if: failure()
         uses: actions/upload-artifact@master
         with:
           name: build-report-${{ matrix.os }}
           path: '**/build/reports'
+
+  test-jvm-compatibility:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 21, 25]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+      - name: Download R8 Jar
+        uses: actions/download-artifact@v6
+        with:
+          name: main-r8-jar
+          path: artifacts
+
+      - name: Run R8 Jar without a tty without enable-native-access all-unnamed
+        run: java -jar artifacts/main-r8.jar
+
+      - name: Run R8 Jar without a tty with enable-native-access all-unnamed
+        run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
+
+      - name: Run R8 Jar with a tty without enable-native-access all-unnamed
+        shell: 'script -q -e -c "bash {0}"'
+        run: java -jar artifacts/main-r8.jar
+
+      - name: Run R8 Jar with a tty with enable-native-access all-unnamed
+        shell: 'script -q -e -c "bash {0}"'
+        run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
+
   publish-snapshot:
     needs: test
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
       - 'docs/**'
       - 'samples/**'
       - '*.md'
+  workflow_dispatch:
+
 jobs:
   test:
     strategy:

--- a/test/proguard/build.gradle.kts
+++ b/test/proguard/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 plugins {
     kotlin("jvm")
 }
@@ -16,6 +19,15 @@ dependencies {
     r8(libs.r8)
 }
 
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JVM_17)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+}
 
 val fatJar by tasks.register<Jar>("fatJar") {
     archiveClassifier = "fat"


### PR DESCRIPTION
Checks that the basics work against the most recent 3 Java LTS releases, with and
without a TTY (faked with `script -q -e -c "bash {0}"`) and with and
without the `--enable-native-access=ALL-UNNAMED` flag that Java 24+
requires to avoid warnings.

This currently fails when running on Java 21 with a TTY and
`--enable-native-access=ALL-UNNAMED`, so I have not made it a
prerequisite for the build passing.

Reference:
https://github.com/ajalt/mordant/issues/278
