### PR TITLE
Fix FFM detection on Java 21 (and 20)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
         run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
 
   publish-snapshot:
-    needs: test
+    needs: test-jvm-compatibility
     runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/master' && github.repository == 'ajalt/mordant' }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
         java-version: [17, 21, 25]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-java@v5
         with:
@@ -93,6 +94,24 @@ jobs:
       - name: Run R8 Jar without a tty with enable-native-access all-unnamed
         run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
 
+  test-jvm-compatibility-interactive-linux:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 21, 25]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+      - name: Download R8 Jar
+        uses: actions/download-artifact@v6
+        with:
+          name: main-r8-jar
+          path: artifacts
+
       - name: Run R8 Jar with a tty without enable-native-access all-unnamed
         shell: 'script -q -e -c "bash {0}"'
         run: java -jar artifacts/main-r8.jar
@@ -101,8 +120,37 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
 
+  test-jvm-compatibility-interactive-macos:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 21, 25]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+      - name: Download R8 Jar
+        uses: actions/download-artifact@v6
+        with:
+          name: main-r8-jar
+          path: artifacts
+
+      - name: Run R8 Jar with a tty without enable-native-access all-unnamed
+        shell: 'script -q /dev/null bash -c "bash {0}"'
+        run: java -jar artifacts/main-r8.jar
+
+      - name: Run R8 Jar with a tty with enable-native-access all-unnamed
+        shell: 'script -q /dev/null bash -c "bash {0}"'
+        run: java --enable-native-access=ALL-UNNAMED -jar artifacts/main-r8.jar
+
   publish-snapshot:
-    needs: test-jvm-compatibility
+    needs:
+      - test-jvm-compatibility
+      - test-jvm-compatibility-interactive-linux
+      - test-jvm-compatibility-interactive-macos
     runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/master' && github.repository == 'ajalt/mordant' }}
     steps:

--- a/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterfaceProvider.ffm.kt
+++ b/mordant-jvm-ffm/src/jvmMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/ffm/TerminalInterfaceProvider.ffm.kt
@@ -7,13 +7,8 @@ import com.oracle.svm.core.annotate.TargetClass
 
 class TerminalInterfaceProviderFfm : TerminalInterfaceProvider {
     override fun load(): TerminalInterface? {
-        try {
-            if (!TerminalInterfaceProviderFfm::class.java.module.isNativeAccessEnabled()) {
-                return null
-            }
-        } catch (e: NoSuchMethodError) {
-           // isNativeAccessEnabled doesn't exist on old JDKs
-           return null
+        if (Runtime.version().feature() < 22 || !TerminalInterfaceProviderFfm::class.java.module.isNativeAccessEnabled()) {
+            return null
         }
         val os = System.getProperty("os.name")
         return when {


### PR DESCRIPTION
On Java versions pre-22 FFM does not work. So disable FFM on Java
versions prior to 22. Should have the side effect that we no longer need
to catch `NoSuchMethodError`.

Fixes https://github.com/ajalt/mordant/issues/278

Adds a smoke test for the latest 3 LTS versions (17, 21 & 25) with and
without a TTY and with and without `--enable-native-access=ALL-UNNAMED`.

Without this, running on Java 20 or 21 in an interactive console and with
`--enable-native-access=ALL-UNNAMED` throws the following exception:

```
java.lang.ClassCastException: Cannot cast java.lang.Integer to java.lang.foreign.MemorySegment
 	at java.base/java.lang.Class.cast(Class.java:4067)
 	at java.base/java.lang.invoke.VarHandles.insertCoordinates(VarHandles.java:501)
 	at java.base/java.lang.invoke.MethodHandles.insertCoordinates(MethodHandles.java:8144)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.FfmLayoutsKt.varHandle(FfmLayouts.kt:133)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.FfmLayoutsKt$shortField$$inlined$scalarField$default$1$1.invoke(FfmLayouts.kt:84)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.FfmLayoutsKt$shortField$$inlined$scalarField$default$1$1.invoke(FfmLayouts.kt:81)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.StructAccessor$DefaultImpls.getValue(FfmLayouts.kt:117)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.MacosCLibrary$winsize.getValue(TerminalInterface.ffm.macos.kt:11)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.MacosCLibrary$winsize.getWs_col(TerminalInterface.ffm.macos.kt:22)
 	at com.github.ajalt.mordant.terminal.terminalinterface.ffm.TerminalInterfaceFfmMacos.getTerminalSize(TerminalInterface.ffm.macos.kt:89)
 	at com.github.ajalt.mordant.terminal.TerminalDetectionKt.detectSize(TerminalDetection.kt:217)
 	at com.github.ajalt.mordant.terminal.Terminal.<init>(Terminal.kt:81)
 	at com.github.ajalt.mordant.terminal.Terminal.<init>(Terminal.kt:60)
 	at com.github.ajalt.mordant.terminal.Terminal.<init>(Terminal.kt:49)
```