### PR TITLE
add SGR mouse parsing on POSIX while preserving legacy X10 behavior

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParser.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParser.kt
@@ -92,7 +92,10 @@ internal class PosixEventParser(
                     read() ?: return null
                 } else if (ch == 'M') {
                     // mouse event
-                    return processMouseEvent(timeout)
+                    return processMouseEventX10(timeout)
+                } else if (ch == '<') {
+                    // SGR mouse event
+                    return processMouseEventSgr(timeout)
                 }
 
                 val cmdStart = s.length - 1
@@ -351,7 +354,7 @@ internal class PosixEventParser(
         )
     }
 
-    private fun processMouseEvent(timeout: TimeMark): InputEvent? {
+    private fun processMouseEventX10(timeout: TimeMark): InputEvent? {
         // Mouse event coordinates are raw values, not decimal text, and they're sometimes utf-8
         // encoded to fit larger values.
         val cb = readUtf8Int(timeout) ?: return null
@@ -362,19 +365,43 @@ internal class PosixEventParser(
         val cy = readUtf8Int(TimeSource.Monotonic.markNow() + 1.milliseconds).let {
             if (it == null) 0 else it - 33
         }
+        val release = (cb and 3) == 3 && (cb and 64) == 0
+        return buildMouseEvent(cb = cb, cx = cx, cy = cy, release = release)
+    }
+
+    private fun processMouseEventSgr(timeout: TimeMark): InputEvent? {
+        val params = StringBuilder()
+        var suffix: Char
+        while (true) {
+            suffix = readRawByte(timeout)?.toChar() ?: return null
+            if (suffix == 'M' || suffix == 'm') break
+            params.append(suffix)
+        }
+
+        val parts = params.split(';')
+        if (parts.size != 3) return null
+
+        val cb = parts[0].toIntOrNull() ?: return null
+        val cx = (parts[1].toIntOrNull() ?: return null) - 1
+        val cy = (parts[2].toIntOrNull() ?: return null) - 1
+        val release = suffix == 'm'
+        return buildMouseEvent(cb = cb, cx = cx, cy = cy, release = release)
+    }
+
+    private fun buildMouseEvent(cb: Int, cx: Int, cy: Int, release: Boolean): MouseEvent {
         val shift = (cb and 4) != 0
         val alt = (cb and 8) != 0
         val ctrl = (cb and 16) != 0
-        // cb == 3 means "a button was released", but there's no way to know which one -_-
+        val isWheel = (cb and 64) != 0
+        val button = cb and 3
         return MouseEvent(
             x = cx,
             y = cy,
-            // On button-motion events, xterm adds 32 to cb
-            left = cb and 3 == 0,
-            right = cb and 3 == 1,
-            middle = cb and 3 == 2,
-            wheelUp = cb == 64,
-            wheelDown = cb == 65,
+            left = !release && !isWheel && button == 0,
+            middle = !release && !isWheel && button == 1,
+            right = !release && !isWheel && button == 2,
+            wheelUp = isWheel && button == 0,
+            wheelDown = isWheel && button == 1,
             ctrl = ctrl,
             alt = alt,
             shift = shift,

--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParser.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParser.kt
@@ -366,7 +366,13 @@ internal class PosixEventParser(
             if (it == null) 0 else it - 33
         }
         val release = (cb and 3) == 3 && (cb and 64) == 0
-        return buildMouseEvent(cb = cb, cx = cx, cy = cy, release = release)
+        return buildMouseEvent(
+            cb = cb,
+            cx = cx,
+            cy = cy,
+            release = release,
+            legacyButtonOrder = true,
+        )
     }
 
     private fun processMouseEventSgr(timeout: TimeMark): InputEvent? {
@@ -385,21 +391,35 @@ internal class PosixEventParser(
         val cx = (parts[1].toIntOrNull() ?: return null) - 1
         val cy = (parts[2].toIntOrNull() ?: return null) - 1
         val release = suffix == 'm'
-        return buildMouseEvent(cb = cb, cx = cx, cy = cy, release = release)
+        return buildMouseEvent(
+            cb = cb,
+            cx = cx,
+            cy = cy,
+            release = release,
+            legacyButtonOrder = false,
+        )
     }
 
-    private fun buildMouseEvent(cb: Int, cx: Int, cy: Int, release: Boolean): MouseEvent {
+    private fun buildMouseEvent(
+        cb: Int,
+        cx: Int,
+        cy: Int,
+        release: Boolean,
+        legacyButtonOrder: Boolean,
+    ): MouseEvent {
         val shift = (cb and 4) != 0
         val alt = (cb and 8) != 0
         val ctrl = (cb and 16) != 0
         val isWheel = (cb and 64) != 0
         val button = cb and 3
+        val middleButtonCode = if (legacyButtonOrder) 2 else 1
+        val rightButtonCode = if (legacyButtonOrder) 1 else 2
         return MouseEvent(
             x = cx,
             y = cy,
             left = !release && !isWheel && button == 0,
-            middle = !release && !isWheel && button == 1,
-            right = !release && !isWheel && button == 2,
+            middle = !release && !isWheel && button == middleButtonCode,
+            right = !release && !isWheel && button == rightButtonCode,
             wheelUp = isWheel && button == 0,
             wheelDown = isWheel && button == 1,
             ctrl = ctrl,

--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterface.posix.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterface.posix.kt
@@ -122,16 +122,16 @@ abstract class TerminalInterfacePosix : StandardTerminalInterface() {
         setStdinTermios(new)
         when (mouseTracking) {
             MouseTracking.Off -> {}
-            MouseTracking.Normal -> print("${CSI}?1006h${CSI}?1000h")
-            MouseTracking.Button -> print("${CSI}?1006h${CSI}?1002h")
-            MouseTracking.Any -> print("${CSI}?1006h${CSI}?1003h")
+            MouseTracking.Normal -> print("${CSI}?1005h${CSI}?1006h${CSI}?1000h")
+            MouseTracking.Button -> print("${CSI}?1005h${CSI}?1006h${CSI}?1002h")
+            MouseTracking.Any -> print("${CSI}?1005h${CSI}?1006h${CSI}?1003h")
         }
         return AutoCloseable {
             when (mouseTracking) {
                 MouseTracking.Off -> {}
-                MouseTracking.Normal -> print("${CSI}?1000l${CSI}?1006l")
-                MouseTracking.Button -> print("${CSI}?1002l${CSI}?1006l")
-                MouseTracking.Any -> print("${CSI}?1003l${CSI}?1006l")
+                MouseTracking.Normal -> print("${CSI}?1000l${CSI}?1006l${CSI}?1005l")
+                MouseTracking.Button -> print("${CSI}?1002l${CSI}?1006l${CSI}?1005l")
+                MouseTracking.Any -> print("${CSI}?1003l${CSI}?1006l${CSI}?1005l")
             }
             setStdinTermios(orig)
         }

--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterface.posix.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/TerminalInterface.posix.kt
@@ -122,12 +122,17 @@ abstract class TerminalInterfacePosix : StandardTerminalInterface() {
         setStdinTermios(new)
         when (mouseTracking) {
             MouseTracking.Off -> {}
-            MouseTracking.Normal -> print("${CSI}?1005h${CSI}?1000h")
-            MouseTracking.Button -> print("${CSI}?1005h${CSI}?1002h")
-            MouseTracking.Any -> print("${CSI}?1005h${CSI}?1003h")
+            MouseTracking.Normal -> print("${CSI}?1006h${CSI}?1000h")
+            MouseTracking.Button -> print("${CSI}?1006h${CSI}?1002h")
+            MouseTracking.Any -> print("${CSI}?1006h${CSI}?1003h")
         }
         return AutoCloseable {
-            if (mouseTracking != MouseTracking.Off) print("${CSI}?1000l")
+            when (mouseTracking) {
+                MouseTracking.Off -> {}
+                MouseTracking.Normal -> print("${CSI}?1000l${CSI}?1006l")
+                MouseTracking.Button -> print("${CSI}?1002l${CSI}?1006l")
+                MouseTracking.Any -> print("${CSI}?1003l${CSI}?1006l")
+            }
             setStdinTermios(orig)
         }
     }
@@ -136,4 +141,3 @@ abstract class TerminalInterfacePosix : StandardTerminalInterface() {
         return PosixEventParser { readRawByte() }.readInputEvent(timeout)
     }
 }
-

--- a/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParserTest.kt
+++ b/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParserTest.kt
@@ -2,6 +2,7 @@ package com.github.ajalt.mordant.terminal.terminalinterface
 
 import com.github.ajalt.mordant.input.MouseEvent
 import io.kotest.matchers.shouldBe
+import kotlin.test.assertIs
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
@@ -53,6 +54,34 @@ class PosixEventParserTest {
         val event = readEvent(x10(cb = 96, cx = 33, cy = 33)) as MouseEvent
         event.wheelUp shouldBe true
         event.wheelDown shouldBe false
+    }
+
+    @Test
+    fun `legacy X10 keeps original middle and right mapping`() {
+        val right = readEvent(x10(cb = 1 + 32, cx = 40, cy = 40)) as MouseEvent
+        right.right shouldBe true
+        right.middle shouldBe false
+
+        val middle = readEvent(x10(cb = 2 + 32, cx = 40, cy = 40)) as MouseEvent
+        middle.middle shouldBe true
+        middle.right shouldBe false
+    }
+
+    @Test
+    fun `parser handles SGR and then X10 sequence`() {
+        val bytes = ("\u001b[<0;5;3M" + x10(cb = 0 + 32, cx = 35, cy = 36)).encodeToByteArray().map { it.toInt() and 0xff }
+        var i = 0
+        val parser = PosixEventParser { if (i < bytes.size) bytes[i++] else null }
+
+        val first = assertIs<MouseEvent>(parser.readInputEvent(TimeSource.Monotonic.markNow() + 1.seconds))
+        first.left shouldBe true
+        first.x shouldBe 4
+        first.y shouldBe 2
+
+        val second = assertIs<MouseEvent>(parser.readInputEvent(TimeSource.Monotonic.markNow() + 1.seconds))
+        second.left shouldBe true
+        second.x shouldBe 2
+        second.y shouldBe 3
     }
 
     private fun readEvent(input: String): Any {

--- a/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParserTest.kt
+++ b/mordant/src/commonTest/kotlin/com/github/ajalt/mordant/terminal/terminalinterface/PosixEventParserTest.kt
@@ -1,0 +1,75 @@
+package com.github.ajalt.mordant.terminal.terminalinterface
+
+import com.github.ajalt.mordant.input.MouseEvent
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class PosixEventParserTest {
+    @Test
+    fun `parses SGR wheel up`() {
+        val event = readEvent("\u001b[<64;11;7M") as MouseEvent
+        event.wheelUp shouldBe true
+        event.wheelDown shouldBe false
+        event.x shouldBe 10
+        event.y shouldBe 6
+    }
+
+    @Test
+    fun `parses SGR left press and release`() {
+        val press = readEvent("\u001b[<0;5;3M") as MouseEvent
+        press.left shouldBe true
+        press.middle shouldBe false
+        press.right shouldBe false
+
+        val release = readEvent("\u001b[<0;5;3m") as MouseEvent
+        release.left shouldBe false
+        release.middle shouldBe false
+        release.right shouldBe false
+    }
+
+    @Test
+    fun `parses SGR right and middle buttons`() {
+        val middle = readEvent("\u001b[<1;8;4M") as MouseEvent
+        middle.middle shouldBe true
+        middle.right shouldBe false
+
+        val right = readEvent("\u001b[<2;8;4M") as MouseEvent
+        right.middle shouldBe false
+        right.right shouldBe true
+    }
+
+    @Test
+    fun `parses SGR modifiers`() {
+        val event = readEvent("\u001b[<20;3;2M") as MouseEvent
+        event.shift shouldBe true
+        event.alt shouldBe false
+        event.ctrl shouldBe true
+    }
+
+    @Test
+    fun `legacy X10 wheel with motion bit still maps as wheel`() {
+        val event = readEvent(x10(cb = 96, cx = 33, cy = 33)) as MouseEvent
+        event.wheelUp shouldBe true
+        event.wheelDown shouldBe false
+    }
+
+    private fun readEvent(input: String): Any {
+        val bytes = input.encodeToByteArray().map { it.toInt() and 0xff }
+        var i = 0
+        val parser = PosixEventParser {
+            if (i < bytes.size) bytes[i++] else null
+        }
+        return parser.readInputEvent(TimeSource.Monotonic.markNow() + 1.seconds)!!
+    }
+
+    private fun x10(cb: Int, cx: Int, cy: Int): String {
+        return buildString {
+            append("\u001b[M")
+            append(cb.toChar())
+            append(cx.toChar())
+            append(cy.toChar())
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds SGR mouse event support on POSIX terminals without breaking existing X10-compatible behavior.
- parse SGR mouse sequences (`CSI < cb;x;y M/m`) in `PosixEventParser`
- keep legacy X10 parsing (`CSI M ...`) and preserve its historical button mapping behavior
- use spec-correct button mapping for SGR events
- enable both mouse encodings in raw mode (`1005` + `1006`) alongside existing tracking modes (`1000/1002/1003`)
- disable both `1005` and `1006` when leaving raw mode
## Why
Modern terminal emulators commonly support and prefer SGR mouse reporting (`1006`) for richer, unambiguous mouse data (larger coordinates and explicit press/release suffixes).  
Examples include **Ghostty** and **WezTerm** (also supported by **Kitty** and recent **iTerm2**).  
Adding SGR support improves interoperability on modern terminals, while preserving X10 behavior avoids regressions for existing Mordant consumers that rely on legacy decoding semantics.
## Compatibility Notes
- **X10 path:** unchanged behavior for button mapping (backward compatible)
- **SGR path:** uses spec-correct middle/right decoding
- Existing mouse tracking modes (`Normal`, `Button`, `Any`) continue to work as before
## Tests
Added/updated `PosixEventParser` tests to cover:
- SGR wheel events
- SGR press/release parsing
- SGR modifier decoding
- legacy X10 wheel compatibility
- legacy X10 middle/right mapping compatibility
- mixed stream parsing (SGR followed by X10)
