### PR TITLE
Add Ghostty to ANSI hyperlink detection

### DIFF
--- a/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/TerminalDetection.kt
+++ b/mordant/src/commonMain/kotlin/com/github/ajalt/mordant/terminal/TerminalDetection.kt
@@ -48,7 +48,7 @@ object TerminalDetection {
         if (forcedColor() == NONE || isCI()) return false
         if (isWindowsTerminal()) return true
         when (getTermProgram()) {
-            "hyper", "wezterm" -> return true
+            "hyper", "wezterm", "ghostty" -> return true
             "iterm.app" -> return iTermVersionSupportsTruecolor()
             "mintty" -> return minttyVersionSupportsHyperlinks()
         }


### PR DESCRIPTION
[Ghostty](https://ghostty.org/) supports OSC8 hyperlinks since https://github.com/ghostty-org/ghostty/pull/1928, which was merged before 1.0.0 was released, so it seems that no version check is needed.